### PR TITLE
Fixes #61 - Adds export to the Support Contract Assignment view

### DIFF
--- a/netbox_lifecycle/views/contract.py
+++ b/netbox_lifecycle/views/contract.py
@@ -195,6 +195,7 @@ class SupportContractAssignmentListView(ObjectListView):
     filterset_form = SupportContractAssignmentFilterForm
     actions = {
         'add': {'add'},
+        'export': {'view'},
         'edit': {'change'},
         'delete': {'delete'},
         'bulk_edit': {'change'},


### PR DESCRIPTION
Adds the export button to the Support Contract Assignments view that has previously been missing